### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 MCP (Model Context Protocol) server để quản trị Matomo Analytics. Server này cung cấp các công cụ để tương tác với Matomo API thông qua giao diện MCP.
 
+<a href="https://glama.ai/mcp/servers/@thichcode/matomo_mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@thichcode/matomo_mcp/badge" alt="Matomo Server MCP server" />
+</a>
+
 ## Tính năng
 
 ### Quản lý Sites


### PR DESCRIPTION
This PR adds a badge for the [Matomo MCP Server](https://glama.ai/mcp/servers/@thichcode/matomo_mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@thichcode/matomo_mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@thichcode/matomo_mcp/badge" alt="Matomo Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.